### PR TITLE
Add help text and some SOC bumper bars around sell decisions

### DIFF
--- a/nsw_script.py
+++ b/nsw_script.py
@@ -1,81 +1,88 @@
 hour = interval_time.hour
 desired_soc = 20.0
+min_sell_soc = 30  # 'Take the money (sell > 80c)' down to this SOC
 sell_price_threshold = 85  # 20 cents
 sell_price_threshold_1 = 20  # sell in morning
 sell_price_threshold_2 = 1000  # Sell during peak
-buy_price_morning = 20  # Morning buy price threshold
+buy_price_morning = 5  # Morning buy price
+# This is when we expect the solar production to meet our house load
+minutes_after_sunrise_solar_matches_load = 30
+solar_production_time = sunrise + timedelta(minutes=minutes_after_sunrise_solar_matches_load)
 
 if 0 <= hour < 6:
     if sell_price > sell_price_threshold:
         action = 'export'
-        reason = 'nsw: sell price greater than 20 cents between midnight and 6am'
-    elif buy_price < 5 and battery_soc >= desired_soc:
+        reason = f'nsw: sell price greater than {sell_price_threshold} cents between midnight and 6am'
+    elif buy_price < buy_price_morning and battery_soc >= desired_soc:
         action = 'import'
-        reason = 'nsw: buy price less than 5 cents between midnight and 6am'
+        reason = f'nsw: buy price less than {buy_price_morning} cents between midnight and 6am'
     else:
         action = 'auto'
         reason = 'nsw: default to auto mode between midnight and 6am'
-
-# FROM 6 AM to 1 PM
+# Stop charging/discharging between 6 AM and 1 PM
 if 6 <= hour < 13:
     if sell_price > sell_price_threshold_1:
         action = 'export'
-        reason = 'nsw: sell price greater than 20 cents between 6am and 1pm'
-    # CHANGED to require battery_soc < 25 and buy_price < 20
-    elif buy_price < buy_price_morning and battery_soc < 25:
+        reason = f'nsw: sell price greater than {sell_price_threshold_1} cents between 6am and 1pm'
+    elif battery_soc > 50 and buy_price > 0:
+        action = 'auto'
+        reason = 'nsw: buy price is over 0 wait for afternoon to buy'
+    elif buy_price < buy_price_morning:
         action = 'import'
-        reason = 'nsw: buy price less than 20 cents and battery SOC below 25% between 6am and 1pm'
+        reason = f'nsw: buy price less than {buy_price_morning} cents between 6am and 1pm'
     else:
         action = 'auto'
         reason = 'nsw: default to auto mode between 6am and 1pm'
-
-# FROM 1 PM to 3 PM
+# Stop charging/discharging between 6 AM and 1 PM
 if 13 <= hour < 15:
     if sell_price > sell_price_threshold_2:
         action = 'export'
-        reason = 'nsw: sell price greater than 20 cents between 1pm and 3pm'
-    # CHANGED battery_soc < 60 to < 25
-    elif battery_soc < 25 and buy_price < 20:
+        reason = f'nsw: sell price greater than {sell_price_threshold_2} cents between 6am and 1pm'
+    elif battery_soc < 60 and buy_price < sell_price_threshold_2:
         action = 'import'
-        reason = 'nsw: buy price less than 20 cents and battery SOC below 25% between 1pm and 3pm'
+        reason = f'nsw: buy price less than {sell_price_threshold_2} cents between 1pm and 3pm'
     else:
         action = 'auto'
-        reason = 'nsw: default to auto mode between 1pm and 3pm'
-
+        reason = 'nsw: default to auto mode between 6am and 1pm'
 if rrp < 0:
-    feed_in_power_limitation = 0
-    reason += f' setting feed in to {feed_in_power_limitation}'
+    feed_in_limitation = 0
+    reason += f' setting feed in to {feed_in_limitation}'
+# Ensure 'auto' action during peak demand times from 3 PM to 9 PM, unless sell_price > 20 cents
 elif 15 <= hour < 21:
     if sell_price > sell_price_threshold and battery_soc >= desired_soc:
         action = 'export'
-        reason = 'nsw: sell price greater than 20 cents during peak hours'
+        reason = f'nsw: sell price greater than {sell_price_threshold} cents during peak hours'
     else:
         action = 'auto'
-        reason = 'nsw: hour between 3pm and 9pm or battery SOC below 20%'
-
+        reason = f'nsw: hour between 3pm and 9pm or battery SOC below {desired_soc}%'
+# Manage battery between 9 PM and midnight
 if 21 <= hour < 24:
     if sell_price > sell_price_threshold:
         action = 'export'
-        reason = 'nsw: sell price greater than 20 cents between 9pm and midnight'
+        reason = f'nsw: sell price greater than {sell_price_threshold} cents between 9pm and midnight'
     elif buy_price < 10 and battery_soc < 30:
         action = 'import'
-        reason = 'nsw: buy price less than 5 cents between 9pm and midnight'
+        reason = 'nsw: buy price less than 10 cents between 9pm and midnight'
     else:
         action = 'auto'
         reason = 'nsw: default to auto mode between 9pm and midnight'
 
-if (hour > 15 or hour < 4) and battery_soc > 80 and sell_price > 25:
-    action = 'export'
-    reason = 'nsw: use it or lose it'
+if (interval_time.hour > 15) and battery_soc > 80 and sell_price > 10:
+    best_upcoming = max(sell_forecast)
+    if best_upcoming < (sell_price + 5):
+        action = 'export'
+        reason = f'nsw: {best_upcoming} < sell within 5c of max'
+    else:
+        reason += f' best upcoming: {best_upcoming}c'
 
-if (hour < 4) and battery_soc > 20 and sell_price > 20:
+if (hour < 5) and battery_soc > desired_soc and sell_price > 20:
     action = 'export'
-    reason = 'nsw: use it or lose it'
+    reason = f'nsw: pre 5am use it or lose it down to {desired_soc}%'
 
-if (3 < hour < 6) and battery_soc > 10 and sell_price > 15:
+if 4 < hour and interval_time < solar_production_time and battery_soc > 10 and sell_price > 15:
     action = 'export'
-    reason = 'nsw: use it or lose it'
+    reason = f'nsw: before solar production time use it or lose it {solar_production_time}'
 
-if rrp > 800 and battery_soc > 30:
+if rrp > 800 and battery_soc > min_sell_soc:
     action = 'export'
-    reason += 'take the money'
+    reason += f'take the money down to {min_sell_soc}%'

--- a/vic_script.py
+++ b/vic_script.py
@@ -3,7 +3,16 @@ desired_soc = 20.0
 sell_price_threshold = 85  # 20 cents
 sell_price_threshold_1 = 20  # sell in morning
 sell_price_threshold_2 = 1000  # Sell during peak
-buy_price_morning = 5  # Morning buy price
+buy_price_morning = 2  # Morning buy price
+# Low battery SOC is 10% and low sell price is 15 cents
+low_battery_soc = 10
+morning_low_sell_price = 15
+# Morning battery SOC is 20% and morning sell price is 20 cents
+morning_battery_soc = 20
+morning_sell_price = 20
+# High battery SOC is 80% and high sell price is 25 cents
+high_battery_soc = 80
+high_min_sell_price = 25
 
 if 0 <= hour < 6:
     if sell_price > sell_price_threshold:
@@ -31,7 +40,7 @@ if 13 <= hour < 15:
     if sell_price > sell_price_threshold_2:
         action = 'export'
         reason = 'vic: sell price greater than 20 cents between 6am and 1pm'
-    elif buy_price < 20:
+    elif buy_price < 20 and battery_soc < 100:
         action = 'import'
         reason = 'vic: buy price less than 25 cents between 1pm and 3pm'
     else:
@@ -50,25 +59,41 @@ if 21 <= hour < 24:
     if sell_price > sell_price_threshold:
         action = 'export'
         reason = 'vic: sell price greater than 20 cents between 9pm and midnight'
-    elif buy_price < 10:
+    elif buy_price < 10 and battery_soc < 100:
         action = 'import'
         reason = 'vic: buy price less than 5 cents between 9pm and midnight'
     else:
         action = 'auto'
         reason = 'vic: default to auto mode between 9pm and midnight'
 
-if (hour > 15 or hour < 4) and battery_soc > 80 and sell_price > 25:
+if (hour > 15 or hour < 4) and battery_soc > high_battery_soc and sell_price > high_min_sell_price:
     action = 'export'
-    reason = 'vic: use it or lose it'
+    reason = f'vic: use it or lose it down to {high_battery_soc}%'
 
-if (hour < 4) and battery_soc > 20 and sell_price > 20:
+if (hour < 4) and battery_soc > morning_battery_soc and sell_price > morning_sell_price:
     action = 'export'
-    reason = 'vic: use it or lose it'
+    reason = f'vic: morning use it or lose it down to {morning_battery_soc}%'
 
-if (3 < hour < 6) and battery_soc > 10 and sell_price > 15:
+if (3 < hour < 6) and battery_soc > low_battery_soc and sell_price > morning_low_sell_price:
     action = 'export'
-    reason = 'vic: use it or lose it'
+    reason = f'vic: morning use it or lose it down to {low_battery_soc}%'
 
 if rrp > 800 and battery_soc > 30:
     action = 'export'
     reason += 'take the money'
+
+if (interval_time.hour > 15) and battery_soc > 50 and sell_price > 20:
+    best_upcoming = max(sell_forecast)
+    if best_upcoming < (sell_price + 10):
+        action = 'export'
+        reason = f'vic: {best_upcoming} < sell within 10c of max'
+    else:
+        reason += f' best upcoming: {best_upcoming}c'
+
+if (interval_time.hour > 15) and battery_soc > 80 and sell_price > 10:
+    best_upcoming = max(sell_forecast)
+    if best_upcoming < (sell_price + 5):
+        action = 'export'
+        reason = f'vic: {best_upcoming} < sell within 5c of max'
+    else:
+        reason += f' best upcoming: {best_upcoming}c'


### PR DESCRIPTION
For NSW and VIC, allow them to sell before the sun top-up and also take lower profits to pay daily but only to a given SOC per cent.